### PR TITLE
Fix: Allow download of script output with "shell" type in .txt format

### DIFF
--- a/src/FileUploader.cpp
+++ b/src/FileUploader.cpp
@@ -217,7 +217,7 @@ namespace OpenWifi {
 							Reader.nextPart(Hdr);
 
 							const auto PartContentType = Hdr.get("Content-Type", "");
-							if (PartContentType == "application/octet-stream") {
+							if (PartContentType == "application/octet-stream" || PartContentType == "text/plain") {
 								std::stringstream FileContent;
 								Poco::StreamCopier::copyStream(Reader.stream(), FileContent);
 								Answer.set("filename", UUID_);


### PR DESCRIPTION
JIRA: https://telecominfraproject.atlassian.net/browse/WIFI-14937

Summary of changes:
- Modified FileUploader to accept both "application/octet-stream" and "text/plain" as valid content types.
- This ensures the controller correctly processes files uploaded by APs when executing shell-type script commands, allowing successful download in `.txt` format.