### PR TITLE
Temporary fix: Validate subscriber tokens in AuthClient

### DIFF
--- a/src/framework/AuthClient.cpp
+++ b/src/framework/AuthClient.cpp
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
 //
 // Created by stephane bourque on 2022-10-25.
 //


### PR DESCRIPTION
[#6] [OWGW][SUBSCRIBER-TOKEN-VALIDATION] Temporary fix: Validate subscriber tokens in AuthClient

Fix Type: Bugfix
Root Cause:
   AuthClient only validated standard session tokens via /validateToken.
   Subscriber tokens were not being validated, causing authentication failures for subscriber API calls.

Solution:
   Temporarily updated AuthClient to validate subscriber tokens using /validateSubToken.
   A proper fix may be needed in the future.