### PR TITLE
[#10][DEFAULT-CONFIGURATION] Fix: Default configuration creation not …

### DIFF
--- a/src/storage/storage_defconfig.cpp
+++ b/src/storage/storage_defconfig.cpp
@@ -237,7 +237,7 @@ namespace OpenWifi {
 				GWObjects::DefaultConfiguration C;
 				Convert(DefConfig, C);
 				for (const auto &Model : C.models) {
-					if ((Model == "*" || Model == DeviceModel) && (Config.platform == Platform)){
+					if ((Model == "*" || Model == DeviceModel) && (C.platform == Platform)){
 						Config = C;
 						return true;
 					}


### PR DESCRIPTION
 [#6] 
[SUBSCRIBER-TOKEN-VALIDATION] Fix: Default configuration creation not working in controller
Fix Type: Bugfix
Root Cause:
  The controller failed to create a default configuration due to incorrect platform matching logic.
Solution:
  Fixed the condition to correctly match platform and model when creating default configuration.