### PR TITLE
Allow persmission to subscriber to delete his own device

### DIFF
--- a/src/RESTAPI/RESTAPI_device_handler.cpp
+++ b/src/RESTAPI/RESTAPI_device_handler.cpp
@@ -52,11 +52,11 @@ namespace OpenWifi {
 			if (!StorageService()->GetDevice(SerialNumber, device)){
 				Logger().error(fmt::format("No device found with serialnumber: [{}]", SerialNumber));
 				return NotFound();
-			} else if (device.subscriber != UserInfo_.userinfo.id){
+			}
+			if (device.subscriber != UserInfo_.userinfo.id){
 				Logger().error(fmt::format("Delete request of device: [{}] denied for subscriber: [{}]", SerialNumber, UserInfo_.userinfo.id));
 				return UnAuthorized(RESTAPI::Errors::ACCESS_DENIED);
 			}
-			Logger().information(fmt::format("Delete request came for device: [{}] of subscriber: [{}]", SerialNumber, UserInfo_.userinfo.id));
 		}
 
 		if (!Utils::NormalizeMac(SerialNumber)) {


### PR DESCRIPTION
[#17]

**Problem Fixed:-**
OWGW did not allow deletion of devices by users other than root and admin user-roles

This PR allows a user with role subscriber to delete devices as well from owgw-devices database.

**Current Behaviour:-**
When a delete device api is called on owgw, its caller's user-role is checked.
If the user-role is not ROOT or ADMIN, then its checked whether the user-role is SUBSCRIBER.
If it is, then deletion of device is allowed. Else the request is denied with error "Unauthorized Access".