### PR TITLE
Fix default configuration creation failing when uuid is missing from configuration JSON

### DIFF
--- a/src/storage/storage_defconfig.cpp
+++ b/src/storage/storage_defconfig.cpp
@@ -63,22 +63,21 @@ namespace OpenWifi {
 			Poco::Data::Session Sess = Pool_->get();
 			Poco::Data::Statement Select(Sess);
 
-			std::string SelectSt{"SELECT name FROM DefaultConfigs WHERE Name=?"};
-			Select << ConvertParams(SelectSt), Poco::Data::Keywords::into(TmpName),
+			std::string St{"SELECT name FROM DefaultConfigs WHERE Name=?"};
+			Select << ConvertParams(St), Poco::Data::Keywords::into(TmpName),
 				Poco::Data::Keywords::use(Name);
 			Select.execute();
 
-			if (!TmpName.empty()) {
+			if (!TmpName.empty())
 				return false;
-			}
 
 				Sess.begin();
 				Poco::Data::Statement Insert(Sess);
 
-				std::string St{"INSERT INTO DefaultConfigs ( " + DB_DefConfig_SelectFields +
+				St = "INSERT INTO DefaultConfigs ( " + DB_DefConfig_SelectFields +
 							   " ) "
 							   "VALUES(" +
-							   DB_DefConfig_InsertValues + ")"};
+							   DB_DefConfig_InsertValues + ")";
 
 				DefConfigRecordTuple R;
 				Convert(DefConfig, R);


### PR DESCRIPTION
[#20 ]

**Problem Fixed:-**

- Previously, creating a default configuration from the Controller required **uuid** to be present in the configuration JSON.
- Because of this, the Controller could not save default configurations and showed **“Cannot create device: invalid configuration”** error.

- This PR allows creating a default configuration without requiring "uuid".

**Current Behavior:-**

- Default configurations can now be created and saved even when the configuration JSON does not include uuid.

**Validation Note:-**

- This change does not reduce validation.
-  CreateDefaultConfiguration() is only called by RESTAPI_default_configuration::DoPost, and that handler already validates the configuration with [ValidateUCentralConfiguration(...)] before calling storage.