### PR TITLE
WS-SVR disconnects with RSA_padding_check_PKCS1_type_1 during device connect

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -76,6 +76,7 @@ if [[ "$TEMPLATE_CONFIG" = 'true' ]]; then
     CERTIFICATES_ALLOWMISMATCH=${CERTIFICATES_ALLOWMISMATCH:-"false"} \
     IPINFO_DEFAULT_COUNTRY=${IPINFO_DEFAULT_COUNTRY:-"US"} \
     DEVICE_SESSION_TIMEOUT=${DEVICE_SESSION_TIMEOUT:-"600"} \
+    LOGGING_LEVEL=${LOGGING_LEVEL:-"information"} \
     envsubst < /"${APP_NAME}".properties.tmpl > "${APP_CONFIG}"/"${APP_NAME}".properties
 fi
 

--- a/owgw.properties.tmpl
+++ b/owgw.properties.tmpl
@@ -182,4 +182,4 @@ archiver.db.3.keep = 7
 ########################################################################
 logging.type = console
 logging.path = $OWGW_ROOT/logs
-logging.level = information
+logging.level = ${LOGGING_LEVEL}

--- a/src/AP_WS_Server.cpp
+++ b/src/AP_WS_Server.cpp
@@ -76,18 +76,14 @@ namespace OpenWifi {
 	bool AP_WS_Server::ValidateCertificate(const std::string &ConnectionId,
 										   const Poco::Crypto::X509Certificate &Certificate) {
 		if (IsCertOk()) {
-			// validate certificate agains trusted chain
-			for (const auto &cert : ClientCasCerts_) {
-				if (Certificate.issuedBy(cert)) {
-					return true;
-				}
-			}
-			poco_warning(
+			if (!Certificate.issuedBy(*IssuerCert_)) {
+				poco_warning(
 					Logger(),
-					fmt::format(
-						"CERTIFICATE({}): issuer mismatch. Certificate not issued by any trusted CA",
-						ConnectionId)
-					);
+					fmt::format("CERTIFICATE({}): issuer mismatch. Local='{}' Incoming='{}'",
+								ConnectionId, IssuerCert_->issuerName(), Certificate.issuerName()));
+				return false;
+			}
+			return true;
 		}
 		return false;
 	}


### PR DESCRIPTION
Devices intermittently disconnect shortly after a successful TLS handshake. The server logs show SSLException ... RSA_padding_check_PKCS1_type_1:invalid padding even though the device cert is valid and the client CA bundle contains the correct root + issuer.

**Observed Behavior**

TLS handshake succeeds and JSON connect frame is received.
~30–60 seconds later, WS-SVR logs:

```
SSLException(...): error:0407008A:rsa routines:RSA_padding_check_PKCS1_type_1:invalid padding
DISCONNECTING(...): ConnectionException: true
```
Removing full CA validation and validating only against the issuer eliminates the disconnects.