### PR TITLE
Allow simulated devices on wifiscan REST path on OWGW

### DIFF
--- a/src/RESTAPI/RESTAPI_device_commandHandler.cpp
+++ b/src/RESTAPI/RESTAPI_device_commandHandler.cpp
@@ -497,10 +497,6 @@ namespace OpenWifi {
 		poco_debug(Logger_, fmt::format("SCRIPT({},{}): TID={} user={} serial={}", CMD_UUID,
 										CMD_RPC, TransactionId_, Requester(), SerialNumber_));
 
-		if(IsDeviceSimulated(SerialNumber_)) {
-			return BadRequest(RESTAPI::Errors::SimulatedDeviceNotSupported);
-		}
-
 		const auto &Obj = ParsedBody_;
 		GWObjects::ScriptRequest SCR;
 		if (!SCR.from_json(Obj)) {
@@ -1014,11 +1010,6 @@ namespace OpenWifi {
 		[[maybe_unused]] const GWObjects::DeviceRestrictions &Restrictions) {
 		poco_debug(Logger_, fmt::format("WIFISCAN({},{}): TID={} user={} serial={}", CMD_UUID,
 										CMD_RPC, TransactionId_, Requester(), SerialNumber_));
-
-
-		if(IsDeviceSimulated(SerialNumber_)) {
-			return BadRequest(RESTAPI::Errors::SimulatedDeviceNotSupported);
-		}
 
 		const auto &Obj = ParsedBody_;
 


### PR DESCRIPTION
**Description:**

This PR enables OWGW to forward wifiscan requests to simulated devices instead of rejecting them.

**Previous behavior:**
    * POST /api/v1/device/{serial}/wifiscan returned 1171: Command not supported on simulated device for simulated APs.
    * OWGW blocked the request before the device-side JSON-RPC command could be sent.

**Requirement addressed:**
    * Simulated devices should be reachable through the same OWGW REST wifiscan path used for real devices.

**Changes:**
    * Removed the simulated-device rejection from the wifiscan REST handler only.
    * Preserved other simulated-device restrictions outside this path.