### PR TITLE
[#50] Publish Ping on kafka Connection Topic

### DIFF
--- a/src/AP_KAFKA_Server.cpp
+++ b/src/AP_KAFKA_Server.cpp
@@ -155,6 +155,9 @@ namespace OpenWifi {
 				if (type == "infra_join") {
 					return HandleInfraJoin(msg, key);
 				}
+				if (type == "infra_ping") {
+					return HandleInfraPing(msg, key);
+				}
 				if (type == "infra_leave") {
 					return HandleInfraLeave(msg, key);
 				}
@@ -248,6 +251,67 @@ namespace OpenWifi {
 		poco_trace(Logger(),
 						 fmt::format("Infra_join: connected {} session={} key='{}'", serial, sessionId,
 									 key));
+	}
+
+	void AP_KAFKA_Server::HandleInfraPing(Poco::JSON::Object::Ptr msg, const std::string &key) {
+		if (!msg->has("ping_message_payload")) {
+			poco_warning(Logger(), "Infra_ping missing 'ping_message_payload'.");
+			return;
+		}
+
+		auto PingPayload = msg->get("ping_message_payload").toString();
+		auto IP = msg->has("infra_public_ip") ? msg->get("infra_public_ip").toString() : "";
+		auto InfraSerial = msg->has("infra_group_infra") ? msg->get("infra_group_infra").toString() : "";
+
+		if (PingPayload.empty() || InfraSerial.empty()) {
+			poco_warning(Logger(), fmt::format("Infra_ping empty field pingPayload: {} InfraSerial:{}", PingPayload, InfraSerial));
+			return;
+		}
+
+		if (!Utils::NormalizeMac(InfraSerial) || !Utils::ValidSerialNumber(InfraSerial)) {
+			poco_warning(Logger(), fmt::format("Infra_ping Invalid infra_group_infra: {}", InfraSerial));
+			return;
+		}
+
+		Poco::JSON::Parser parser;
+		auto pingParsed = parser.parse(PingPayload).extract<Poco::JSON::Object::Ptr>();
+		if (!pingParsed || !pingParsed->has(uCentralProtocol::METHOD) ||
+				Poco::icompare(pingParsed->get(uCentralProtocol::METHOD).toString(), uCentralProtocol::PING) != 0) {
+			poco_warning(Logger(), "Infra_ping has invalid 'ping_message_payload' method.");
+			return;
+		}
+
+		Poco::JSON::Object::Ptr params;
+		if (!pingParsed->isObject(uCentralProtocol::PARAMS) ||
+			!(params = pingParsed->getObject(uCentralProtocol::PARAMS)) || params->size() == 0) {
+			poco_warning(Logger(), "Infra_ping has invalid 'ping_message_payload' params.");
+			return;
+		}
+
+		if (!params->has(uCentralProtocol::SERIAL)) {
+			poco_warning(Logger(), "Infra_ping payload missing params.serial.");
+			return;
+		}
+
+		auto serial = Poco::trim(Poco::toLower(params->get(uCentralProtocol::SERIAL).toString()));
+		if (!Utils::NormalizeMac(serial) || !Utils::ValidSerialNumber(serial)) {
+			poco_warning(Logger(), fmt::format("Infra_ping Invalid serial: {}", serial));
+			return;
+		}
+
+		if (InfraSerial != serial) {
+			poco_warning(Logger(), fmt::format("Infra_ping serial mismatch: infra='{}' ping='{}'", InfraSerial, serial));
+			return;
+		}
+
+		params->set(uCentralProtocol::SERIAL, serial);
+		if (!params->has(uCentralProtocol::CONNECTIONIP) && !IP.empty()) {
+			params->set(uCentralProtocol::CONNECTIONIP, serial + "@" + IP);
+		}
+
+		std::ostringstream normalizedPayload;
+		pingParsed->stringify(normalizedPayload);
+		HandleDeviceMessage(pingParsed, key, normalizedPayload.str());
 	}
 
 	void AP_KAFKA_Server::InitDbSessions() {

--- a/src/AP_KAFKA_Server.h
+++ b/src/AP_KAFKA_Server.h
@@ -40,6 +40,7 @@ namespace OpenWifi {
 
 		void OnKafkaMessage(const std::string &key, const std::string &payload);
 		void HandleInfraJoin(Poco::JSON::Object::Ptr msg, const std::string &key);
+		void HandleInfraPing(Poco::JSON::Object::Ptr msg, const std::string &key);
 		void HandleInfraLeave(Poco::JSON::Object::Ptr msg, const std::string &key);
 		void HandleDeviceMessage(Poco::JSON::Object::Ptr msg, const std::string &key,
 								 const std::string &payload);

--- a/src/AP_Process_ping.cpp
+++ b/src/AP_Process_ping.cpp
@@ -8,16 +8,100 @@
 //
 
 #include "AP_Connection.h"
+
+#include <Poco/String.h>
+
+#include "FindCountry.h"
 #include "fmt/format.h"
+#include "framework/KafkaManager.h"
+#include "framework/KafkaTopics.h"
 #include "framework/ow_constants.h"
+#include "framework/utils.h"
 
 namespace OpenWifi {
 	void AP_Connection::Process_ping(Poco::JSON::Object::Ptr ParamsObj) {
-		if (ParamsObj->has(uCentralProtocol::UUID)) {
-			[[maybe_unused]] uint64_t UUID = ParamsObj->get(uCentralProtocol::UUID);
-			poco_trace(Logger_, fmt::format("PING({}): Current config is {}", CId_, UUID));
-		} else {
-			poco_warning(Logger_, fmt::format("PING({}): Missing parameter.", CId_));
+		if (!ParamsObj->has(uCentralProtocol::UUID) || !ParamsObj->has(uCentralProtocol::SERIAL)) {
+			poco_warning(Logger_, fmt::format("PING({}): Missing required uuid or serial.", CId_));
+			return;
 		}
+
+		auto serial = Poco::trim(Poco::toLower(ParamsObj->get(uCentralProtocol::SERIAL).toString()));
+		if (!Utils::NormalizeMac(serial) || !Utils::ValidSerialNumber(serial)) {
+			poco_warning(Logger_, fmt::format("PING({}): Invalid serial {}.", CId_, serial));
+			return;
+		}
+
+		std::uint64_t UUID = ParamsObj->get(uCentralProtocol::UUID);
+		auto firmware = ParamsObj->has(uCentralProtocol::FIRMWARE)
+							? ParamsObj->get(uCentralProtocol::FIRMWARE).toString()
+							: State_.Firmware;
+		auto compatible = ParamsObj->has(uCentralProtocol::COMPATIBLE)
+							  ? ParamsObj->get(uCentralProtocol::COMPATIBLE).toString()
+							  : Compatible_;
+
+		std::string connectionIp;
+		if (ParamsObj->has(uCentralProtocol::CONNECTIONIP)) {
+			connectionIp = ParamsObj->get(uCentralProtocol::CONNECTIONIP).toString();
+		} else if (!Address_.empty()) {
+			connectionIp = serial + "@" + Address_;
+		} else {
+			connectionIp = CId_;
+		}
+
+		std::string locale;
+		if (ParamsObj->has("locale")) {
+			locale = ParamsObj->get("locale").toString();
+		} else {
+			auto IP = Address_;
+			if (IP.empty()) {
+				auto atPos = connectionIp.find('@');
+				IP = atPos == std::string::npos ? connectionIp : connectionIp.substr(atPos + 1);
+			}
+			if (!IP.empty() && IP.substr(0, 7) == "::ffff:") {
+				IP = IP.substr(7);
+			}
+			locale = IP.empty() ? State_.locale : FindCountryFromIP()->Get(IP);
+		}
+
+		SerialNumber_ = serial;
+		SerialNumberInt_ = Utils::SerialNumberToInt(serial);
+		if (!firmware.empty()) {
+			State_.Firmware = firmware;
+		}
+		if (!compatible.empty()) {
+			Compatible_ = compatible;
+			State_.Compatible = compatible;
+		}
+		if (!locale.empty()) {
+			State_.locale = locale;
+		}
+		if (!connectionIp.empty()) {
+			CId_ = connectionIp;
+			auto atPos = connectionIp.find('@');
+			Address_ = atPos == std::string::npos ? connectionIp : connectionIp.substr(atPos + 1);
+			State_.Address = Address_;
+		}
+
+		poco_trace(Logger_, fmt::format("PING({}): received uuid={} serial={}", CId_, UUID, serial));
+
+		if (!KafkaManager()->Enabled()) {
+			return;
+		}
+
+		Poco::JSON::Object PingObject;
+		Poco::JSON::Object PingDetails;
+		PingDetails.set(uCentralProtocol::FIRMWARE, firmware);
+		PingDetails.set(uCentralProtocol::SERIALNUMBER, serial);
+		PingDetails.set(uCentralProtocol::COMPATIBLE, compatible);
+		PingDetails.set(uCentralProtocol::CONNECTIONIP, connectionIp);
+		PingDetails.set(uCentralProtocol::TIMESTAMP, Utils::Now());
+		PingDetails.set(uCentralProtocol::UUID, UUID);
+		if (!locale.empty()) {
+			PingDetails.set("locale", locale);
+		}
+		PingObject.set(uCentralProtocol::PING, PingDetails);
+
+		poco_trace(Logger_, fmt::format("PING({}): sending kafka event for {}", CId_, serial));
+		KafkaManager()->PostMessage(KafkaTopics::CONNECTION, serial, PingObject);
 	}
 } // namespace OpenWifi


### PR DESCRIPTION
## Description
Currently, only **capabilities** and **disconnection** events are being published to the Kafka `connection` topic. The **ping** event is not being published.

## Current Behaviour
- Kafka `connection` topic receives:
  - Capabilities events
  - Disconnection events
- Ping events are **not published**

## Expected Behaviour
- Kafka `connection` topic should also receive:
  - Ping events (heartbeat updates)
- This will ensure consistent tracking of device connectivity and real-time status monitoring
