### PR TITLE
fix(framework): load full CA certificate chain instead of first block

### DIFF
--- a/src/framework/SubSystemServer.cpp
+++ b/src/framework/SubSystemServer.cpp
@@ -49,11 +49,21 @@ namespace OpenWifi {
 
 		if (!cert_file_.empty() && !key_file_.empty()) {
 			Poco::Crypto::X509Certificate Cert(cert_file_);
-			Poco::Crypto::X509Certificate Root(root_ca_);
-
 			Context->useCertificate(Cert);
-			Context->addChainCertificate(Root);
-			Context->addCertificateAuthority(Root);
+
+			if (!root_ca_.empty()) {
+				try {
+					std::vector<Poco::Crypto::X509Certificate> RootCerts =
+						Poco::Net::X509Certificate::readPEM(root_ca_);
+					for (const auto &rc : RootCerts) {
+						Context->addChainCertificate(rc);
+						Context->addCertificateAuthority(rc);
+					}
+				} catch (const Poco::Exception &E) {
+					L.fatal(fmt::format("Failed to load CA certificate chain from {}: {}", root_ca_, E.displayText()));
+					throw;
+				}
+			}
 
 			if (level_ == Poco::Net::Context::VERIFY_STRICT) {
 				if (issuer_cert_file_.empty()) {


### PR DESCRIPTION
fix #52 

# Summary

This PR fixes an SSL context initialization bug where only the first certificate block from the CA file, `root_ca_`, was loaded and presented during the TLS handshake.

## Problem

In `SubSystemServer::CreateSecureSocket`, CA certificates were previously loaded using:

```cpp
Poco::Crypto::X509Certificate Root(root_ca_);
```

This constructor only parses the first PEM certificate block in the file and ignores any additional certificate blocks.

This became an issue after Let's Encrypt's transition to the new **Generation Y** hierarchy, which may require presenting a three-certificate chain, including a cross-signed **Root YR bridge certificate**, to remain compatible with older devices and trust stores.

Without the bridge certificate, strict TLS clients such as Postman with SSL certificate verification enabled rejected connections with the following error:

```text
unable to get local issuer certificate
```

## Solution

`CreateSecureSocket` has been updated to load all CA certificates from the PEM file using:

```cpp
Poco::Net::X509Certificate::readPEM(root_ca_)
```

The resulting certificate vector is then iterated so that each intermediate or bridge certificate is added to the SSL context.

The implementation also includes a safe `try-catch` block that catches `Poco::Exception`, logs the parse failure details using `L.fatal`, and rethrows the exception.


## Testing

Verified the certificate chain using:

```bash
openssl s_client -connect <host>:16002 -showcerts
```

Confirmed that all three certificates are now successfully presented during the TLS handshake:

```text
Leaf certificate
YR1 intermediate certificate
Root YR bridge certificate
```

Also verified that strict TLS clients can successfully establish secure connections to the server, including:

* Postman with SSL Certificate Verification turned ON
